### PR TITLE
Add additional environment variables to export

### DIFF
--- a/lib/aws_runas/main.rb
+++ b/lib/aws_runas/main.rb
@@ -81,10 +81,10 @@ module AwsRunAs
       env['AWS_REGION'] = @cfg.load_config_value(key: 'region')    
       if @no_role
         env['AWS_SESSION_EXPIRATION'] = "#{session_credentials.expiration}"
-        env['AWS_SESSION_EXPIRATION_EPOCH'] = DateTime.parse("#{session_credentials.expiration}").strftime('%s')
+        env['AWS_SESSION_EXPIRATION_UNIX'] = DateTime.parse("#{session_credentials.expiration}").strftime('%s')
       else
         env['AWS_SESSION_EXPIRATION'] = "#{@session.expiration}"
-        env['AWS_SESSION_EXPIRATION_EPOCH'] = DateTime.parse("#{@session.expiration}").strftime('%s')          
+        env['AWS_SESSION_EXPIRATION_UNIX'] = DateTime.parse("#{@session.expiration}").strftime('%s')          
         env['AWS_RUNAS_ASSUMED_ROLE_ARN'] = @cfg.load_config_value(key: 'role_arn')
       end
       env

--- a/lib/aws_runas/main.rb
+++ b/lib/aws_runas/main.rb
@@ -74,7 +74,13 @@ module AwsRunAs
       env['AWS_SECRET_ACCESS_KEY'] = @role_credentials.secret_access_key
       env['AWS_SESSION_TOKEN'] = @role_credentials.session_token
       env['AWS_RUNAS_PROFILE'] = @cfg.profile
-      env['AWS_RUNAS_ASSUMED_ROLE_ARN'] = @cfg.load_config_value(key: 'role_arn') unless @no_role
+      env['AWS_REGION'] = @cfg.load_config_value(key: 'region')
+      if @no_role
+        env['AWS_SESSION_EXPIRATION'] = "#{@role_credentials.expiration}"
+        env['AWS_SESSION_EXPIRATION_EPOCH'] = DateTime.parse("#{@role_credentials.expiration}").strftime('%s')
+      else 
+        env['AWS_RUNAS_ASSUMED_ROLE_ARN'] = @cfg.load_config_value(key: 'role_arn')
+      end
       env
     end
 

--- a/lib/aws_runas/main.rb
+++ b/lib/aws_runas/main.rb
@@ -52,33 +52,39 @@ module AwsRunAs
       mfa_serial = @cfg.load_config_value(key: 'mfa_serial') unless ENV.include?('AWS_SESSION_TOKEN')
       if @no_role
         raise 'No mfa_serial in selected profile, session will be useless' if mfa_serial.nil?
-        @role_credentials = sts_client.get_session_token(
+        @session = sts_client.get_session_token(
           duration_seconds: 3600,
           serial_number: mfa_serial,
           token_code: @mfa_code
-        ).credentials
+        )        
       else
-        @role_credentials = Aws::AssumeRoleCredentials.new(
+        @session = Aws::AssumeRoleCredentials.new(
           client: sts_client,
           role_arn: role_arn,
           serial_number: mfa_serial,
           token_code: @mfa_code,
           role_session_name: session_id
-        ).credentials
+        )
       end
+    end
+
+    def session_credentials
+      @session.credentials
     end
 
     def credentials_env
       env = {}
-      env['AWS_ACCESS_KEY_ID'] = @role_credentials.access_key_id
-      env['AWS_SECRET_ACCESS_KEY'] = @role_credentials.secret_access_key
-      env['AWS_SESSION_TOKEN'] = @role_credentials.session_token
+      env['AWS_ACCESS_KEY_ID'] = session_credentials.access_key_id
+      env['AWS_SECRET_ACCESS_KEY'] = session_credentials.secret_access_key
+      env['AWS_SESSION_TOKEN'] = session_credentials.session_token
       env['AWS_RUNAS_PROFILE'] = @cfg.profile
-      env['AWS_REGION'] = @cfg.load_config_value(key: 'region')
+      env['AWS_REGION'] = @cfg.load_config_value(key: 'region')    
       if @no_role
-        env['AWS_SESSION_EXPIRATION'] = "#{@role_credentials.expiration}"
-        env['AWS_SESSION_EXPIRATION_EPOCH'] = DateTime.parse("#{@role_credentials.expiration}").strftime('%s')
-      else 
+        env['AWS_SESSION_EXPIRATION'] = "#{session_credentials.expiration}"
+        env['AWS_SESSION_EXPIRATION_EPOCH'] = DateTime.parse("#{session_credentials.expiration}").strftime('%s')
+      else
+        env['AWS_SESSION_EXPIRATION'] = "#{@session.expiration}"
+        env['AWS_SESSION_EXPIRATION_EPOCH'] = DateTime.parse("#{@session.expiration}").strftime('%s')          
         env['AWS_RUNAS_ASSUMED_ROLE_ARN'] = @cfg.load_config_value(key: 'role_arn')
       end
       env

--- a/spec/aws_runas/main_spec.rb
+++ b/spec/aws_runas/main_spec.rb
@@ -145,13 +145,13 @@ describe AwsRunAs::Main do
       it 'has AWS_RUNAS_ASSUMED_ROLE_ARN set to the assumed role ARN' do
         expect(env['AWS_RUNAS_ASSUMED_ROLE_ARN']).to eq('arn:aws:iam::123456789012:role/test-admin')
       end
-      it 'has AWS_SESSION_EXPIRATION set to the session expiration' do
+      it 'has AWS_SESSION_EXPIRATION set in env' do
         expect(env['AWS_SESSION_EXPIRATION']).to eq('2017-07-10 19:56:11 UTC')
       end
-      it 'has AWS_SESSION_EXPIRATION_EPOCH set to the session expiration' do
+      it 'has AWS_SESSION_EXPIRATION_EPOCH set in env' do
         expect(env['AWS_SESSION_EXPIRATION_EPOCH']).to eq('1499716571')
       end      
-      it 'has AWS_REGION set to the session expiration' do
+      it 'has AWS_REGION set in env' do
         expect(env['AWS_REGION']).to eq('us-west-1')
       end                       
     end
@@ -162,12 +162,12 @@ describe AwsRunAs::Main do
       it 'does not have AWS_RUNAS_ASSUMED_ROLE_ARN set' do
         expect(env).to_not have_key('AWS_RUNAS_ASSUMED_ROLE_ARN')
       end
-      it 'has AWS_SESSION_EXPIRATION set to the session expiration' do
+      it 'has AWS_SESSION_EXPIRATION set in env' do
         expect(env['AWS_SESSION_EXPIRATION']).to eq('2017-07-10 19:56:11 UTC')
       end
-      it 'has AWS_SESSION_EXPIRATION_EPOCH set to the session expiration' do
+      it 'has AWS_SESSION_EXPIRATION_EPOCH set in env' do
         expect(env['AWS_SESSION_EXPIRATION_EPOCH']).to eq('1499716571')
-      end
+      end      
       it 'has AWS_REGION set to the session expiration' do
         expect(env['AWS_REGION']).to eq('us-west-1')
       end      

--- a/spec/aws_runas/main_spec.rb
+++ b/spec/aws_runas/main_spec.rb
@@ -114,6 +114,7 @@ describe AwsRunAs::Main do
           }
         )
       )
+      allow_any_instance_of(Aws::AssumeRoleCredentials).to receive(:expiration).and_return(Time.utc(2017, "jul", 10, 19, 56, 11))
     end
     subject(:env) do
       ENV.delete('AWS_SESSION_TOKEN')
@@ -129,7 +130,7 @@ describe AwsRunAs::Main do
     let(:no_role) { false }
 
     context 'with role assumed' do 
-      it 'returns AWS_ACCESS_KEY_ID set in env' do 
+      it 'returns AWS_ACCESS_KEY_ID set in env' do        
         expect(env['AWS_ACCESS_KEY_ID']).to eq('accessKeyIdType')
       end
       it 'returns AWS_SECRET_ACCESS_KEY set in env' do
@@ -144,6 +145,12 @@ describe AwsRunAs::Main do
       it 'has AWS_RUNAS_ASSUMED_ROLE_ARN set to the assumed role ARN' do
         expect(env['AWS_RUNAS_ASSUMED_ROLE_ARN']).to eq('arn:aws:iam::123456789012:role/test-admin')
       end
+      it 'has AWS_SESSION_EXPIRATION set to the session expiration' do
+        expect(env['AWS_SESSION_EXPIRATION']).to eq('2017-07-10 19:56:11 UTC')
+      end
+      it 'has AWS_SESSION_EXPIRATION_EPOCH set to the session expiration' do
+        expect(env['AWS_SESSION_EXPIRATION_EPOCH']).to eq('1499716571')
+      end      
       it 'has AWS_REGION set to the session expiration' do
         expect(env['AWS_REGION']).to eq('us-west-1')
       end                       

--- a/spec/aws_runas/main_spec.rb
+++ b/spec/aws_runas/main_spec.rb
@@ -148,8 +148,8 @@ describe AwsRunAs::Main do
       it 'has AWS_SESSION_EXPIRATION set in env' do
         expect(env['AWS_SESSION_EXPIRATION']).to eq('2017-07-10 19:56:11 UTC')
       end
-      it 'has AWS_SESSION_EXPIRATION_EPOCH set in env' do
-        expect(env['AWS_SESSION_EXPIRATION_EPOCH']).to eq('1499716571')
+      it 'has AWS_SESSION_EXPIRATION_UNIX set in env' do
+        expect(env['AWS_SESSION_EXPIRATION_UNIX']).to eq('1499716571')
       end      
       it 'has AWS_REGION set in env' do
         expect(env['AWS_REGION']).to eq('us-west-1')
@@ -165,10 +165,10 @@ describe AwsRunAs::Main do
       it 'has AWS_SESSION_EXPIRATION set in env' do
         expect(env['AWS_SESSION_EXPIRATION']).to eq('2017-07-10 19:56:11 UTC')
       end
-      it 'has AWS_SESSION_EXPIRATION_EPOCH set in env' do
-        expect(env['AWS_SESSION_EXPIRATION_EPOCH']).to eq('1499716571')
+      it 'has AWS_SESSION_EXPIRATION_UNIX set in env' do
+        expect(env['AWS_SESSION_EXPIRATION_UNIX']).to eq('1499716571')
       end      
-      it 'has AWS_REGION set to the session expiration' do
+      it 'has AWS_REGION set in env' do
         expect(env['AWS_REGION']).to eq('us-west-1')
       end      
     end


### PR DESCRIPTION
Useful info for doing various things, like customizing your ZSH prompt 😎 

Example:

Dropping into an aws-runas shell:

![image](https://user-images.githubusercontent.com/1631363/28041673-2f345ccc-657f-11e7-9825-e11fd83bbded.png)

Same shell once the session expires:

![image](https://user-images.githubusercontent.com/1631363/28041708-5707b0d2-657f-11e7-9b67-31d95f00997b.png)

ZSH Prompt function below (probably have to use a powerline theme to use this as-is, but you can modify as you see fit):

```
prompt_aws_runas() {
  local aws_runas_profile="$AWS_RUNAS_PROFILE"
  local aws_session_expiration="$AWS_SESSION_EXPIRATION_UNIX"

  if [[ -n "$aws_runas_profile" ]]; then
    if [[ $aws_session_expiration > $(date +%s) ]]; then
      "$1_prompt_segment" "$0" "$2" green white "$aws_runas_profile" 'AWS_ICON'
    else
      "$1_prompt_segment" "$0" "$2" red white "$aws_runas_profile" 'AWS_ICON'
    fi
  fi
}
```