### PR TITLE
Adding system username to the name of the Assumed Session

### DIFF
--- a/lib/aws_runas/main.rb
+++ b/lib/aws_runas/main.rb
@@ -47,7 +47,8 @@ module AwsRunAs
     end
 
     def assume_role
-      session_id = "aws-runas-session_#{Time.now.to_i}"
+      username = AwsRunAs::Utils.get_user()
+      session_id = "aws-runas-session_#{username}_#{Time.now.to_i}"
       role_arn = @cfg.load_config_value(key: 'role_arn')
       mfa_serial = @cfg.load_config_value(key: 'mfa_serial') unless ENV.include?('AWS_SESSION_TOKEN')
       if @no_role

--- a/lib/aws_runas/utils.rb
+++ b/lib/aws_runas/utils.rb
@@ -30,9 +30,9 @@ module AwsRunAs
 
     def get_user
       if ENV['OS'].to_s.include? "Windows"
-        username = ENV['USERNAME']
+        username = ENV['USERNAME'].to_s
       else
-        username = ENV['USER']
+        username = ENV['USER'].to_s
       end
       username
     end

--- a/lib/aws_runas/utils.rb
+++ b/lib/aws_runas/utils.rb
@@ -28,6 +28,15 @@ module AwsRunAs
       File.expand_path('../../../shell_profiles', __FILE__)
     end
 
+    def get_user
+      if ENV['OS'].to_s.include? "Windows"
+        username = ENV['USERNAME']
+      else
+        username = ENV['USER']
+      end
+      username
+    end
+
     # Run an interactive bash session with a special streamed RC file.  The RC
     # merges a local .bashrc if it exists, with a prompt that includes the
     # computed message from handoff_to_shell.

--- a/lib/aws_runas/version.rb
+++ b/lib/aws_runas/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module AwsRunAs
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/spec/aws_runas/utils_spec.rb
+++ b/spec/aws_runas/utils_spec.rb
@@ -16,6 +16,10 @@ require 'spec_helper'
 require 'tmpdir'
 
 describe AwsRunAs::Utils do
+  describe '::get_user' do
+      expect(AwsRunAs::Utils.get_user).is_a? String
+  end
+
   describe '::shell_profiles_dir' do
     it 'returns an existent path' do
       expect(File.directory?(AwsRunAs::Utils.shell_profiles_dir)).to be true

--- a/spec/aws_runas/utils_spec.rb
+++ b/spec/aws_runas/utils_spec.rb
@@ -17,7 +17,13 @@ require 'tmpdir'
 
 describe AwsRunAs::Utils do
   describe '::get_user' do
+    it 'returns a string' do
       expect(AwsRunAs::Utils.get_user).is_a? String
+    end
+
+    it 'is not null' do
+      expect(AwsRunAs::Utils.get_user).not_to be_empty
+    end
   end
 
   describe '::shell_profiles_dir' do

--- a/spec/aws_runas/utils_spec.rb
+++ b/spec/aws_runas/utils_spec.rb
@@ -27,7 +27,8 @@ describe AwsRunAs::Utils do
 
     it 'returns user if running on windows' do
       ENV['OS'] = 'Windows_NT'
-      expect(AwsRunAs::Utils.get_user).is_a? String
+      ENV['USERNAME'] = "testtricker"
+      expect(AwsRunAs::Utils.get_user).to eq("testtricker")
     end
   end
 

--- a/spec/aws_runas/utils_spec.rb
+++ b/spec/aws_runas/utils_spec.rb
@@ -24,6 +24,11 @@ describe AwsRunAs::Utils do
     it 'is not null' do
       expect(AwsRunAs::Utils.get_user).not_to be_empty
     end
+
+    it 'returns user if running on windows' do
+      ENV['OS'] = 'Windows_NT'
+      expect(AwsRunAs::Utils.get_user).is_a? String
+    end
   end
 
   describe '::shell_profiles_dir' do


### PR DESCRIPTION
The name of the AWS session did not include any identifiable information pertaining to the user assuming the role. Cloudtrail saw these changes as "aws-runas_session_%timestamp". Adding the system username to the session name creates a trail back to the user.

Note: This is not using the IAM username, but the Computer Users username. The IAM username would require get-user permissions in IAM in the calling account, which isn't likely available if you're enforcing a "users can only assume roles in other accounts" policy.