### PR TITLE
ZSH PROMPT Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.5.1
+
+Fixed the bug where the current PROMPT was not supporting
+shell functions and colors but rather just rendering the old prompt code
+as text. https://github.com/vancluever/aws-runas/issues/13
+
 ## v0.5.0
 
 ### Zsh Support

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ shells:
    returns 0 on true and 1 on false, which can be used semantically in shell
    scripts.
  * `aws_session_status_color`, which works off of `aws_session_expired` to
-   render an ANSI numeric color code - red when `aws_session_expired` is `true`,
-   yellow otherwise.
+   render either an ANSI color number (for bash)
+   or a human readable color name (for zsh)
+   - (red or 31) when `aws_session_expired` is `true`, (yellow or 33) otherwise.
 
 #### Skipping the Fancy Prompt
 

--- a/lib/aws_runas/utils.rb
+++ b/lib/aws_runas/utils.rb
@@ -37,7 +37,7 @@ module AwsRunAs
       rc_file.write("#{rc_data}\n") unless rc_data.nil?
       rc_file.write(IO.read("#{shell_profiles_dir}/sh.profile"))
       unless skip_prompt
-        rc_file.write("PS1=\"\\[\\e[\\$(aws_session_status_color)m\\](#{message})\\[\\e[0m\\] $PS1\"\n")
+        rc_file.write("PS1=\"\\[\\e[\\$(aws_session_status_color \"bash\")m\\](#{message})\\[\\e[0m\\] $PS1\"\n")
       end
       rc_file.close
       system(env, path, '--rcfile', rc_file.path)
@@ -56,8 +56,8 @@ module AwsRunAs
       rc_file.write(IO.read("#{shell_profiles_dir}/sh.profile"))
       unless skip_prompt
         rc_file.write("setopt PROMPT_SUBST\n")
-        rc_file.write("export OLDPROMPT=\"${PROMPT}\"\n")
-        rc_file.write("PROMPT=$'%{\\e[\\%}$(aws_session_status_color)m(#{message})%{\\e[0m%} $OLDPROMPT'\n")
+        rc_file.write("OLDPROMPT=\"$PROMPT\"\n")
+        rc_file.write("PROMPT=\"%F{$(aws_session_status_color \"zsh\")}(#{message})%f $OLDPROMPT\"\n")
       end
       rc_file.close
       env.store('ZDOTDIR', rc_dir)

--- a/lib/aws_runas/version.rb
+++ b/lib/aws_runas/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module AwsRunAs
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/shell_profiles/sh.profile
+++ b/shell_profiles/sh.profile
@@ -10,14 +10,21 @@ aws_session_expired() {
   return 1
 }
 
-# aws_session_status_color returns an ANSI color number for the specific status
+# aws_session_status_color returns either an ANSI color number (for bash)
+# or a human readable color name (for zsh) for the specific status
 # of the session. Note that if session_expired is not correctly functioning,
 # this will always be yellow. Red is shown when it's verified that the session
 # has expired.
 aws_session_status_color() {
   if aws_session_expired; then
-    echo "31"
+    if [[ "$1" == zsh ]]; then
+      echo "red"
+    fi
+      echo "31"
   else
-    echo "33"
+    if [[ "$1" == zsh ]]; then
+      echo "yellow"
+    fi
+      echo "33"
   fi
 }

--- a/spec/helpers/utils_spec.rb
+++ b/spec/helpers/utils_spec.rb
@@ -11,10 +11,10 @@ ZSHRC_FILE_CONTENTS = <<EOS.freeze
 bazqux
 EOS
 
-BASHRC_EXPECTED_PROMPT   = "PS1=\"\\[\\e[\\$(aws_session_status_color)m\\](AWS:rspec)\\[\\e[0m\\] $PS1\"\n".freeze
-ZSHRC_EXPECTED_PROMPT    = "PROMPT=$'%{\\e[\\%}$(aws_session_status_color)m(AWS:rspec)%{\\e[0m%} $OLDPROMPT'\n".freeze
+BASHRC_EXPECTED_PROMPT   = "PS1=\"\\[\\e[\\$(aws_session_status_color \"bash\")m\\](AWS:rspec)\\[\\e[0m\\] $PS1\"\n".freeze
+ZSHRC_EXPECTED_PROMPT    = "PROMPT=\"%F{$(aws_session_status_color \"zsh\")}(AWS:rspec)%f $OLDPROMPT\"\n".freeze
 ZSHRC_EXPECTED_SETSUBST  = "setopt PROMPT_SUBST\n".freeze
-ZSHRC_EXPECTED_OLDPROMPT = "export OLDPROMPT=\"${PROMPT}\"\n".freeze
+ZSHRC_EXPECTED_OLDPROMPT = "OLDPROMPT=\"$PROMPT\"\n".freeze
 ZSH_MOCK_TMPDIR          = "#{Dir.tmpdir}/aws_runas_zsh_rspec".freeze
 
 EXPECTED_ENV = {


### PR DESCRIPTION
Fixed the bug where the current PROMPT was not supporting shell functions and colors but rather just rendering the old prompt code as text. https://github.com/vancluever/aws-runas/issues/13

Updated `aws_session_status_color` to return either an ANSI color number (for bash) or a human readable color name (for zsh).

For the ZSH handoff, the way the ANSI color number was being parsed before the rendering of the OLDPROMPT environment variable was translating the old prompt as text rather than as shell functions.