### PR TITLE
Adding support for custom assume role session duration up to 12 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.6.0
+
+Added support for maximum 12 hour duration session credentials
+
 ## v0.5.0
 
 ### Zsh Support
@@ -27,7 +31,7 @@ The default interactive prompt that you get when you run `aws-runas` with no
 command supplied can now by skipped by adding `--skip-prompt` to the CLI
 arguments. The profile functions mentioned above are still passed in. This
 allows you to leverage their functionality inside your own scripts and custom
-prompts if you want in other ways. 
+prompts if you want in other ways.
 
 ### Additional Variables
 

--- a/aws_runas.gemspec
+++ b/aws_runas.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ['>= 2.2.6']
 
-  spec.add_dependency 'aws-sdk', '~> 2.6'
+  spec.add_dependency 'aws-sdk', '~> 2.11'
   spec.add_dependency 'inifile', '~> 3.0'
   spec.add_dependency 'trollop', '~> 2.1'
 

--- a/lib/aws_runas/cli.rb
+++ b/lib/aws_runas/cli.rb
@@ -40,6 +40,7 @@ module AwsRunAs
         opt :skip_prompt, 'Do not launch interactive sessions with the fancy prompt', type: TrueClass, default: nil
         opt :path, 'Path to the AWS config file', type: String
         opt :profile, 'The AWS profile to load', type: String, default: 'default'
+        opt :duration, 'The duration in seconds for temporary credentials', type: Integer, default: 3600
         stop_on_unknown
       end
     end
@@ -49,7 +50,7 @@ module AwsRunAs
     def start
       opts = load_opts
       mfa_code = read_mfa_if_needed(path: opts[:path], profile: opts[:profile])
-      @main = AwsRunAs::Main.new(path: opts[:path], profile: opts[:profile], mfa_code: mfa_code, no_role: opts[:no_role])
+      @main = AwsRunAs::Main.new(path: opts[:path], profile: opts[:profile], mfa_code: mfa_code, no_role: opts[:no_role], duration_seconds: opts[:duration])
       @main.assume_role
       command = ARGV.shift
       @main.handoff(command: command, argv: ARGV, skip_prompt: opts[:skip_prompt])

--- a/lib/aws_runas/main.rb
+++ b/lib/aws_runas/main.rb
@@ -26,7 +26,7 @@ module AwsRunAs
   # and hands off environment to called process.
   class Main
     # Instantiate the object and set up the path, profile, and populate MFA
-    def initialize(path: nil, profile: default, mfa_code: nil, no_role: nil)
+    def initialize(path: nil, profile: default, mfa_code: nil, no_role: nil, duration_seconds: 3600)
       cfg_path = if path
                    path
                  else
@@ -35,6 +35,7 @@ module AwsRunAs
       @cfg = AwsRunAs::Config.new(path: cfg_path, profile: profile)
       @mfa_code = mfa_code
       @no_role = no_role
+      @duration_seconds = duration_seconds
     end
 
     def sts_client
@@ -63,7 +64,8 @@ module AwsRunAs
           role_arn: role_arn,
           serial_number: mfa_serial,
           token_code: @mfa_code,
-          role_session_name: session_id
+          role_session_name: session_id,
+          duration_seconds: @duration_seconds
         )
       end
     end

--- a/lib/aws_runas/version.rb
+++ b/lib/aws_runas/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module AwsRunAs
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
Attempting to resolve #15 

I didn't integrate this into the get_session_token functionality as I'm not sure that's compatible with the numbers that are possible on assume role.